### PR TITLE
update zig to 0.10.0-dev.352+c9ae24503

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install [zig](http://ziglang.org/).
 zig build
 ```
 
-Executable binary is at `./zig-cache/bin/hexdump-zip`.
+Executable binary is at `./zig-out/bin/hexdump-zip`.
 
 ## Run
 


### PR DESCRIPTION
update zig to 0.10.0-dev.352+c9ae24503

works also with zig 0.9.0
replace output bin path in README.md
replace `std.debug.warn` by `std.debug.print`
replace `*std.mem.Allocator` by `std.mem.Allocator`
replace `false` by `.lower` for `std.fmt.formatIntBuf()` calls
remove unused param `self` from `detectedMauCorruption()`